### PR TITLE
HashRouter added to the module instead of BrowserRouter

### DIFF
--- a/app/js/openmrs-owa-built-in-reports.jsx
+++ b/app/js/openmrs-owa-built-in-reports.jsx
@@ -11,13 +11,13 @@
  */
 import React from 'react';
 import { render } from 'react-dom';
-import { Router, Route, hashHistory, BrowserRouter } from 'react-router-dom';
+import { Router, Route, hashHistory, HashRouter } from 'react-router-dom';
 
 import routes from './routes';
 
 const packageJson = require("../manifest.webapp");
 render((
-  <BrowserRouter basename={"/openmrs/owa/openmrs-owa-built-in-reports-" + packageJson.version} history={hashHistory}>
+  <HashRouter history={hashHistory}>
     {routes()}
-  </BrowserRouter>
+  </HashRouter>
 ), document.getElementById('app'));


### PR DESCRIPTION
## Description ## 

Built-in-reports module uses BrowserRouter for the routing. It's fail while refreshing the web page or pressing back button in the browser. It should be fixed with HashRouter to resolve this issue while we are using the React Router V4.

BaseName can be removed if we are using the HashRouter instead of BrowserRouter.

## Ticket ## 

https://issues.openmrs.org/browse/BIR-3