### PR TITLE
BIR-10 Added improvements to the Visit Notes report

### DIFF
--- a/app/js/components/reports/NumberOfVisitNotes/NumberOfVisitNotes.jsx
+++ b/app/js/components/reports/NumberOfVisitNotes/NumberOfVisitNotes.jsx
@@ -3,6 +3,10 @@ import ReportAsTableView from '../common/ReportAsTableView';
 import ReportTitle from '../common/ReportTitle';
 import DateRangeInput from '../common/DateRangeInput';
 import moment from 'moment';
+import LocationInput from '../common/LocationInput';
+import InfoMessage from '../common/InfoMessage';
+import ReportAsPieChart from '../common/ReportAsPieChart';
+import NumberOfVisitNotesInputBox from './NumberOfVisitNotesInputBox';
 
 /**
  * Display the result of Number of Visit Notes report
@@ -12,16 +16,20 @@ class NumberOfVisitNotes extends Component {
   constructor() {
     super();
     let dateStart = moment().subtract(1, 'months').format('YYYY-MM-DD');
-    let dateEnd = moment().format('YYYY-MM-DD');
+    let dateEnd = moment().add(1,'days').format('YYYY-MM-DD');
     this.state = {
       parameters: {
         startDate: dateStart,
-        endDate: dateEnd
+        endDate: dateEnd,
+        location: '',
+        activeVisits: false
       }
     };
     this.getReportUUID = this.getReportUUID.bind(this);
     this.eventListenerForStartDate = this.eventListenerForStartDate.bind(this);
     this.eventListenerForEndDate = this.eventListenerForEndDate.bind(this);
+    this.handleLocationSelector = this.handleLocationSelector.bind(this);
+    this.eventListenerForParameter = this.eventListenerForParameter.bind(this);
   }
 
   getReportUUID() {
@@ -34,7 +42,9 @@ class NumberOfVisitNotes extends Component {
       this.setState(prevState => ({
         parameters: {
           startDate: moment(selectedDate).format('YYYY-MM-DD'),
-          endDate: prevState.parameters.endDate
+          endDate: prevState.parameters.endDate,
+          location: prevState.parameters.location,
+          activeVisits: prevState.parameters.activeVisits
         }
       }));
     }
@@ -46,11 +56,36 @@ class NumberOfVisitNotes extends Component {
       this.setState(prevState => ({
         parameters: {
           startDate: prevState.parameters.startDate,
-          endDate: moment(selectedDate).format('YYYY-MM-DD')
+          // Set next day as the end date to select the visits upto today end.
+          endDate: moment(selectedDate).add(1,'days').format('YYYY-MM-DD'),
+          location: prevState.parameters.location,
+          activeVisits: prevState.parameters.activeVisits
         }
       }));
     }
   }
+
+  handleLocationSelector(event) {
+    this.setState({
+      parameters: {
+        location: event.target.value,
+        startDate: this.state.parameters.startDate,
+        endDate: this.state.parameters.endDate,
+        activeVisits: this.state.parameters.activeVisits
+      }
+    });
+  }
+
+  eventListenerForParameter(e) {
+    this.setState(prevState => ({
+      parameters: {
+        startDate: prevState.parameters.startDate,
+        endDate: prevState.parameters.endDate,
+        location: prevState.parameters.location,
+        activeVisits: !prevState.parameters.activeVisits
+      }
+    }));
+}
 
   render() {
     return (
@@ -62,9 +97,20 @@ class NumberOfVisitNotes extends Component {
           etdlistener={this.eventListenerForEndDate}
           initStD={this.state.parameters.startDate}
           initEtD={this.state.parameters.endDate} />
+        <NumberOfVisitNotesInputBox listener={this.eventListenerForParameter} />
 
-        <ReportAsTableView reportUUID={this.getReportUUID()}
-          reportParameters={this.state.parameters} />
+        <LocationInput locationListener={this.handleLocationSelector}/>
+        {this.state.parameters.location != null && this.state.parameters.location != '' ? (
+          <div>
+            <ReportAsTableView reportUUID={this.getReportUUID()}
+              reportParameters={this.state.parameters} />
+            <ReportAsPieChart reportUUID={this.getReportUUID()}
+                reportParameters={this.state.parameters}
+                labels="VisitType" qty="Count" limit={10} />
+          </div>
+        ) : (
+          <InfoMessage componentName="location" />
+        )}
       </div>
     );
   }

--- a/app/js/components/reports/NumberOfVisitNotes/NumberOfVisitNotesInputBox.jsx
+++ b/app/js/components/reports/NumberOfVisitNotes/NumberOfVisitNotesInputBox.jsx
@@ -1,0 +1,30 @@
+import React, { Component, PropTypes } from 'react';
+import '../ListOfUsers/ListOfUsersInputBox.css'; 
+
+/**
+ * This component will render the input div which appear at the top of the page
+ */
+class NumberOfVisitNotessInputBox extends Component {
+
+
+  render() {
+    return (
+      <div className="inputBoxWrapper">
+        <div className="innerWrapper">
+          <label className="textLabel">Include Active Visits : </label>
+          <div className="toggleContainerLOU">
+            <label className="switch">
+              <input type="checkbox" onChange={this.props.listener} />
+              <span className="slider round"/>
+            </label>
+          </div>
+        </div>
+      </div>);
+  }
+}
+
+NumberOfVisitNotessInputBox.propTypes = {
+  listener: PropTypes.func.isRequired
+};
+
+export default NumberOfVisitNotessInputBox;


### PR DESCRIPTION
## Description ## 

Reference Meta Data module has Visit Notes report which can give a number of total visit notess for given date period. The content of that report doesn't enough for a better report. So the report has improved with following contents,

- Total Number of visit notes grouped by visit types.
- Users should able to get the visit notes report for all locations or a given location.
- Bar chart should be added into the bottom of the report as usual.
- Users can include and exclude the active visits in the report
- Changed the end Date selection to support current day end. So users can get the reports up to current day end including active visits


## Ticket ## 

https://issues.openmrs.org/browse/BIR-10