### PR TITLE
BIR-15 Added callback function to write file function to avoid build error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,9 @@ let getConfig = function () {
       'LOCAL_OWA_FOLDER': '/home/user/openmrs/server/owa/',
       'APP_ENTRY_POINT': 'http://localhost:8080/openmrs/owa/openmrs-owa-builtinreports-1.0.0/index.html'
     };
-    fs.writeFile('config.json', JSON.stringify(config));
+    fs.writeFile('config.json', JSON.stringify(config), function(err, result) {
+      if(err) console.log('error', err);
+    });
     return config;
   } finally {
     // console.log("return the config");


### PR DESCRIPTION
**Summary :** Issue fix for https://issues.openmrs.org/browse/BIR-15

**Tests :** Not applicable

**Expected result :** When building the module using `npm install || npm run build:prod` should not give TypeError [ERR_INVALID_CALLBACK]: Callback must be a function 