### PR TITLE
BIR-22 Fix Logout is not working

### DIFF
--- a/app/js/components/common/Header.jsx
+++ b/app/js/components/common/Header.jsx
@@ -126,12 +126,10 @@ export class Header extends Component {
             </li>
           </NavLink>
 
-          <NavLink to="" activeClassName="active">
-            <li>
+          <li class='logout'>
               <a href="/openmrs/appui/header/logout.action?successUrl=openmrs">Logout {' '}
                 <span className="glyphicon glyphicon-log-out" /></a>
-            </li>
-          </NavLink>
+          </li>
         </ul>
       </header>
     );


### PR DESCRIPTION
Summary : issue fix for https://issues.openmrs.org/browse/BIR-22

Tests : Not applicable

Expected output : Should be able to logout now reason not working was you can't have <a> tag inside <NavLink>.